### PR TITLE
Add firmware and Kotlin control app with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+firmware/build/
+android-app/.gradle/
+android-app/app/build/
+.gradle/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # minitrain
+
+Ce projet contient une implémentation complète d'un système de pilotage pour un mini-train connecté, avec un firmware C++ ciblant l'ESP32 (simulé ici) et une application Android (logique Kotlin testable côté JVM).
+
+## Structure
+
+- `firmware/` : code C++17 modulaire (contrôleur PID, gestion des commandes, agrégation de télémétrie) avec une application console de simulation et une suite de tests unitaires.
+- `android-app/` : logique applicative Kotlin (encodage des commandes, dépôt réseau basé sur Ktor, ViewModel coroutines) et tests unitaires JVM.
+
+## Prérequis
+
+- CMake ≥ 3.16 et un compilateur C++17 (g++, clang++…)
+- Java 17+ et Gradle (Wrapper fourni via Gradle installé sur la machine)
+
+## Lancer les tests
+
+### Firmware C++
+
+```bash
+cmake -S firmware -B firmware/build
+cmake --build firmware/build
+ctest --test-dir firmware/build
+```
+
+### Application Kotlin
+
+```bash
+cd android-app
+gradle test
+```
+
+Les tests valident l'ensemble des comportements critiques : PID, agrégateur de télémétrie, traitement des commandes, logique de ViewModel et interactions réseau simulées.

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.serialization")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation("io.ktor:ktor-client-core:2.3.12")
+    implementation("io.ktor:ktor-client-cio:2.3.12")
+    implementation("io.ktor:ktor-client-content-negotiation:2.3.12")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.12")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+    testImplementation("io.ktor:ktor-client-mock:2.3.12")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/android-app/app/src/main/kotlin/com/minitrain/app/model/TrainModels.kt
+++ b/android-app/app/src/main/kotlin/com/minitrain/app/model/TrainModels.kt
@@ -1,0 +1,36 @@
+package com.minitrain.app.model
+
+import kotlinx.serialization.Serializable
+
+enum class Direction {
+    FORWARD,
+    REVERSE
+}
+
+@Serializable
+data class TrainCommand(
+    val command: String,
+    val value: String? = null
+)
+
+@Serializable
+data class Telemetry(
+    val speedMetersPerSecond: Double,
+    val motorCurrentAmps: Double,
+    val batteryVoltage: Double,
+    val temperatureCelsius: Double,
+    val headlights: Boolean,
+    val horn: Boolean,
+    val direction: Direction,
+    val emergencyStop: Boolean
+)
+
+@Serializable
+data class ControlState(
+    val targetSpeed: Double,
+    val direction: Direction,
+    val headlights: Boolean,
+    val horn: Boolean,
+    val emergencyStop: Boolean
+)
+

--- a/android-app/app/src/main/kotlin/com/minitrain/app/network/CommandEncoder.kt
+++ b/android-app/app/src/main/kotlin/com/minitrain/app/network/CommandEncoder.kt
@@ -1,0 +1,34 @@
+package com.minitrain.app.network
+
+import com.minitrain.app.model.ControlState
+import com.minitrain.app.model.Direction
+import com.minitrain.app.model.Telemetry
+import com.minitrain.app.model.TrainCommand
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+object CommandEncoder {
+    private val json = Json { encodeDefaults = true }
+
+    fun encode(command: TrainCommand): String {
+        val builder = StringBuilder()
+        builder.append("command=").append(command.command)
+        command.value?.let {
+            builder.append(";value=").append(it)
+        }
+        return builder.toString()
+    }
+
+    fun encodeState(state: ControlState): String = json.encodeToString(state)
+}
+
+object TelemetryParser {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun parse(raw: String): Telemetry = json.decodeFromString(raw)
+}
+
+fun Direction.toProtocolValue(): String = when (this) {
+    Direction.FORWARD -> "forward"
+    Direction.REVERSE -> "reverse"
+}

--- a/android-app/app/src/main/kotlin/com/minitrain/app/repository/TrainRepository.kt
+++ b/android-app/app/src/main/kotlin/com/minitrain/app/repository/TrainRepository.kt
@@ -1,0 +1,51 @@
+package com.minitrain.app.repository
+
+import com.minitrain.app.model.ControlState
+import com.minitrain.app.model.Telemetry
+import com.minitrain.app.model.TrainCommand
+import com.minitrain.app.network.CommandEncoder
+import com.minitrain.app.network.TelemetryParser
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+open class TrainRepository(
+    private val baseUrl: String,
+    private val client: HttpClient = HttpClient {
+        install(ContentNegotiation) {
+            json()
+        }
+    }
+) {
+
+    open suspend fun sendCommand(command: TrainCommand): Unit = withContext(Dispatchers.IO) {
+        val payload = CommandEncoder.encode(command)
+        client.post("$baseUrl/command") {
+            contentType(ContentType.Text.Plain)
+            setBody(payload)
+        }
+        Unit
+    }
+
+    open suspend fun pushState(state: ControlState): Unit = withContext(Dispatchers.IO) {
+        val serialized = CommandEncoder.encodeState(state)
+        client.post("$baseUrl/state") {
+            contentType(ContentType.Application.Json)
+            setBody(serialized)
+        }
+        Unit
+    }
+
+    open suspend fun fetchTelemetry(): Telemetry = withContext(Dispatchers.IO) {
+        val response = client.get("$baseUrl/telemetry").body<String>()
+        TelemetryParser.parse(response)
+    }
+}

--- a/android-app/app/src/main/kotlin/com/minitrain/app/ui/TrainViewModel.kt
+++ b/android-app/app/src/main/kotlin/com/minitrain/app/ui/TrainViewModel.kt
@@ -1,0 +1,86 @@
+package com.minitrain.app.ui
+
+import com.minitrain.app.model.ControlState
+import com.minitrain.app.model.Direction
+import com.minitrain.app.model.Telemetry
+import com.minitrain.app.model.TrainCommand
+import com.minitrain.app.network.toProtocolValue
+import com.minitrain.app.repository.TrainRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class TrainViewModel(
+    private val repository: TrainRepository,
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+) {
+    private val _telemetry = MutableStateFlow<Telemetry?>(null)
+    val telemetry: StateFlow<Telemetry?> = _telemetry.asStateFlow()
+
+    private val _controlState = MutableStateFlow(
+        ControlState(
+            targetSpeed = 0.0,
+            direction = Direction.FORWARD,
+            headlights = false,
+            horn = false,
+            emergencyStop = false
+        )
+    )
+    val controlState: StateFlow<ControlState> = _controlState.asStateFlow()
+
+    private var pollingJob: Job? = null
+
+    fun setTargetSpeed(speed: Double) {
+        val sanitized = speed.coerceIn(0.0, 5.0)
+        _controlState.value = _controlState.value.copy(targetSpeed = sanitized, emergencyStop = false)
+        sendState()
+    }
+
+    fun toggleHeadlights(enabled: Boolean) {
+        _controlState.value = _controlState.value.copy(headlights = enabled)
+        scope.launch { repository.sendCommand(TrainCommand("headlights", if (enabled) "on" else "off")) }
+    }
+
+    fun toggleHorn(enabled: Boolean) {
+        _controlState.value = _controlState.value.copy(horn = enabled)
+        scope.launch { repository.sendCommand(TrainCommand("horn", if (enabled) "on" else "off")) }
+    }
+
+    fun setDirection(direction: Direction) {
+        _controlState.value = _controlState.value.copy(direction = direction)
+        scope.launch { repository.sendCommand(TrainCommand("set_direction", direction.toProtocolValue())) }
+    }
+
+    fun emergencyStop() {
+        _controlState.value = _controlState.value.copy(targetSpeed = 0.0, emergencyStop = true)
+        scope.launch { repository.sendCommand(TrainCommand("emergency")) }
+    }
+
+    private fun sendState() {
+        val state = _controlState.value
+        scope.launch { repository.pushState(state) }
+    }
+
+    fun startTelemetryPolling(interval: Duration = 1.seconds) {
+        pollingJob?.cancel()
+        pollingJob = scope.launch {
+            while (true) {
+                val telemetry = withContext(Dispatchers.Default) { repository.fetchTelemetry() }
+                _telemetry.value = telemetry
+                kotlinx.coroutines.delay(interval)
+            }
+        }
+    }
+
+    fun stopTelemetryPolling() {
+        pollingJob?.cancel()
+        pollingJob = null
+    }
+}

--- a/android-app/app/src/test/kotlin/com/minitrain/app/CommandEncoderTest.kt
+++ b/android-app/app/src/test/kotlin/com/minitrain/app/CommandEncoderTest.kt
@@ -1,0 +1,56 @@
+package com.minitrain.app
+
+import com.minitrain.app.model.ControlState
+import com.minitrain.app.model.Direction
+import com.minitrain.app.model.Telemetry
+import com.minitrain.app.model.TrainCommand
+import com.minitrain.app.network.CommandEncoder
+import com.minitrain.app.network.TelemetryParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CommandEncoderTest {
+    @Test
+    fun `encode command with value`() {
+        val command = TrainCommand("set_speed", "1.5")
+        val encoded = CommandEncoder.encode(command)
+        assertEquals("command=set_speed;value=1.5", encoded)
+    }
+
+    @Test
+    fun `encode state to json`() {
+        val state = ControlState(1.2, Direction.FORWARD, headlights = true, horn = false, emergencyStop = false)
+        val json = CommandEncoder.encodeState(state)
+        assertTrue(json.contains("\"targetSpeed\":1.2"))
+        assertTrue(json.contains("\"direction\":\"FORWARD\""))
+    }
+
+    @Test
+    fun `parse telemetry json`() {
+        val telemetry = Telemetry(1.0, 0.5, 11.1, 30.0, true, false, Direction.FORWARD, false)
+        val raw = CommandEncoder.encodeState(
+            ControlState(
+                targetSpeed = telemetry.speedMetersPerSecond,
+                direction = telemetry.direction,
+                headlights = telemetry.headlights,
+                horn = telemetry.horn,
+                emergencyStop = telemetry.emergencyStop
+            )
+        )
+        val parsed = TelemetryParser.parse(
+            """{
+                "speedMetersPerSecond": ${telemetry.speedMetersPerSecond},
+                "motorCurrentAmps": ${telemetry.motorCurrentAmps},
+                "batteryVoltage": ${telemetry.batteryVoltage},
+                "temperatureCelsius": ${telemetry.temperatureCelsius},
+                "headlights": ${telemetry.headlights},
+                "horn": ${telemetry.horn},
+                "direction": "${telemetry.direction}",
+                "emergencyStop": ${telemetry.emergencyStop}
+            }"""
+        )
+        assertEquals(telemetry, parsed)
+        assertTrue(raw.contains("targetSpeed"))
+    }
+}

--- a/android-app/app/src/test/kotlin/com/minitrain/app/TrainRepositoryTest.kt
+++ b/android-app/app/src/test/kotlin/com/minitrain/app/TrainRepositoryTest.kt
@@ -1,0 +1,89 @@
+package com.minitrain.app
+
+import com.minitrain.app.model.ControlState
+import com.minitrain.app.model.Direction
+import com.minitrain.app.model.Telemetry
+import com.minitrain.app.model.TrainCommand
+import com.minitrain.app.repository.TrainRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.statement.readBytes
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TrainRepositoryTest {
+    @Test
+    fun `send command posts encoded payload`() = runBlocking {
+        lateinit var capturedRequest: HttpRequestData
+        val engine = MockEngine { request ->
+            capturedRequest = request
+            respond(content = "OK", status = HttpStatusCode.OK, headers = headersOf(HttpHeaders.ContentType, ContentType.Text.Plain.toString()))
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
+        val repository = TrainRepository("http://localhost", client)
+
+        repository.sendCommand(TrainCommand("set_speed", "1.0"))
+
+        assertEquals(HttpMethod.Post, capturedRequest.method)
+        val body = capturedRequest.body as TextContent
+        assertEquals("command=set_speed;value=1.0", body.text)
+    }
+
+    @Test
+    fun `fetch telemetry parses json`() = runBlocking {
+        val telemetry = Telemetry(1.0, 0.5, 11.1, 30.0, true, false, Direction.FORWARD, false)
+        val engine = MockEngine {
+            respond(
+                content = """{
+                    "speedMetersPerSecond": ${telemetry.speedMetersPerSecond},
+                    "motorCurrentAmps": ${telemetry.motorCurrentAmps},
+                    "batteryVoltage": ${telemetry.batteryVoltage},
+                    "temperatureCelsius": ${telemetry.temperatureCelsius},
+                    "headlights": ${telemetry.headlights},
+                    "horn": ${telemetry.horn},
+                    "direction": "${telemetry.direction}",
+                    "emergencyStop": ${telemetry.emergencyStop}
+                }""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
+        val repository = TrainRepository("http://localhost", client)
+
+        val parsed = repository.fetchTelemetry()
+        assertEquals(telemetry, parsed)
+    }
+
+    @Test
+    fun `push state posts json`() = runBlocking {
+        lateinit var captured: HttpRequestData
+        val engine = MockEngine { request ->
+            captured = request
+            respond("OK", HttpStatusCode.OK, headersOf())
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
+        val repository = TrainRepository("http://localhost", client)
+
+        val state = ControlState(1.0, Direction.REVERSE, true, false, false)
+        repository.pushState(state)
+
+        assertEquals(HttpMethod.Post, captured.method)
+        val contentType = captured.headers[HttpHeaders.ContentType]
+        assertTrue(contentType == null || contentType.startsWith("application/json"))
+        val body = captured.body as TextContent
+        assertTrue(body.text.contains("\"direction\":\"REVERSE\""))
+    }
+}

--- a/android-app/app/src/test/kotlin/com/minitrain/app/TrainViewModelTest.kt
+++ b/android-app/app/src/test/kotlin/com/minitrain/app/TrainViewModelTest.kt
@@ -1,0 +1,85 @@
+package com.minitrain.app
+
+import com.minitrain.app.model.ControlState
+import com.minitrain.app.model.Direction
+import com.minitrain.app.model.Telemetry
+import com.minitrain.app.model.TrainCommand
+import com.minitrain.app.repository.TrainRepository
+import com.minitrain.app.ui.TrainViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+private class FakeRepository : TrainRepository("http://localhost") {
+    val commands = mutableListOf<TrainCommand>()
+    val states = mutableListOf<ControlState>()
+    private val telemetryResponses = ArrayDeque<Telemetry>()
+
+    fun enqueueTelemetry(vararg telemetry: Telemetry) {
+        telemetryResponses.addAll(telemetry)
+    }
+
+    override suspend fun sendCommand(command: TrainCommand) {
+        commands.add(command)
+    }
+
+    override suspend fun pushState(state: ControlState) {
+        states.add(state)
+    }
+
+    override suspend fun fetchTelemetry(): Telemetry {
+        if (telemetryResponses.isEmpty()) error("No telemetry enqueued")
+        return telemetryResponses.removeFirst()
+    }
+}
+
+class TrainViewModelTest {
+    @Test
+    fun `setting speed updates state and resets emergency`() = runBlocking {
+        val repository = FakeRepository()
+        val viewModel = TrainViewModel(repository, this)
+
+        viewModel.emergencyStop()
+        assertTrue(viewModel.controlState.first().emergencyStop)
+        viewModel.setTargetSpeed(2.0)
+        kotlinx.coroutines.yield()
+
+        val state = viewModel.controlState.first()
+        assertEquals(2.0, state.targetSpeed)
+        assertFalse(state.emergencyStop)
+        assertEquals(1, repository.states.size)
+    }
+
+    @Test
+    fun `polling telemetry emits updates`() = runBlocking {
+        val repository = FakeRepository()
+        val viewModel = TrainViewModel(repository, this)
+        val telemetry = Telemetry(1.0, 0.5, 11.1, 30.0, true, false, Direction.FORWARD, false)
+        repository.enqueueTelemetry(telemetry, telemetry.copy(speedMetersPerSecond = 1.5))
+
+        val job = launch { viewModel.startTelemetryPolling(10.milliseconds) }
+        val first = viewModel.telemetry.first { it != null }
+        assertEquals(telemetry, first)
+        delay(15)
+        viewModel.stopTelemetryPolling()
+        job.cancel()
+    }
+
+    @Test
+    fun `direction command sent`() = runBlocking {
+        val repository = FakeRepository()
+        val viewModel = TrainViewModel(repository, this)
+
+        viewModel.setDirection(Direction.REVERSE)
+        kotlinx.coroutines.yield()
+        assertEquals(Direction.REVERSE, viewModel.controlState.first().direction)
+        assertTrue(repository.commands.any { it.command == "set_direction" && it.value == "reverse" })
+    }
+}

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    kotlin("jvm") version "2.0.21" apply false
+    kotlin("plugin.serialization") version "2.0.21" apply false
+}
+
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/android-app/settings.gradle.kts
+++ b/android-app/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "minitrain-android"
+include(":app")

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.16)
+project(minitrain_firmware LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_library(minitrain_core
+    src/pid_controller.cpp
+    src/train_state.cpp
+    src/telemetry.cpp
+    src/command_processor.cpp
+    src/train_controller.cpp
+)
+
+target_include_directories(minitrain_core PUBLIC include)
+
+target_compile_options(minitrain_core PRIVATE -Wall -Wextra -Wpedantic)
+
+add_executable(minitrain_sim main/main.cpp)
+target_link_libraries(minitrain_sim PRIVATE minitrain_core)
+
+add_executable(minitrain_tests
+    tests/test_main.cpp
+    tests/test_pid_controller.cpp
+    tests/test_telemetry.cpp
+    tests/test_command_processor.cpp
+    tests/test_train_controller.cpp
+)
+
+target_link_libraries(minitrain_tests PRIVATE minitrain_core)
+
+target_compile_options(minitrain_tests PRIVATE -Wall -Wextra -Wpedantic)
+
+enable_testing()
+add_test(NAME firmware_tests COMMAND minitrain_tests)

--- a/firmware/include/minitrain/command_processor.hpp
+++ b/firmware/include/minitrain/command_processor.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "minitrain/train_state.hpp"
+
+namespace minitrain {
+
+struct CommandResult {
+    bool success{false};
+    std::string message;
+};
+
+class CommandProcessor {
+  public:
+    using CommandHandler = std::function<CommandResult(const std::unordered_map<std::string, std::string> &)>;
+
+    CommandProcessor();
+
+    CommandResult process(const std::string &commandText);
+    void registerHandler(const std::string &name, CommandHandler handler);
+
+  private:
+    std::unordered_map<std::string, CommandHandler> handlers_;
+
+    static std::unordered_map<std::string, std::string> parseKeyValuePairs(const std::string &commandText);
+};
+
+} // namespace minitrain

--- a/firmware/include/minitrain/pid_controller.hpp
+++ b/firmware/include/minitrain/pid_controller.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <chrono>
+
+namespace minitrain {
+
+class PidController {
+  public:
+    PidController(float kp, float ki, float kd, float minOutput, float maxOutput);
+
+    float update(float target, float measurement, std::chrono::steady_clock::duration dt);
+    void reset();
+
+  private:
+    float kp_;
+    float ki_;
+    float kd_;
+    float minOutput_;
+    float maxOutput_;
+    float integral_;
+    float previousError_;
+    bool hasPreviousError_;
+};
+
+} // namespace minitrain

--- a/firmware/include/minitrain/telemetry.hpp
+++ b/firmware/include/minitrain/telemetry.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+namespace minitrain {
+
+struct TelemetrySample {
+    float speedMetersPerSecond{0.0F};
+    float motorCurrentAmps{0.0F};
+    float batteryVoltage{0.0F};
+    float temperatureCelsius{0.0F};
+};
+
+class TelemetryAggregator {
+  public:
+    explicit TelemetryAggregator(std::size_t windowSize = 10);
+
+    void addSample(const TelemetrySample &sample);
+    [[nodiscard]] std::optional<TelemetrySample> average() const;
+    [[nodiscard]] std::vector<TelemetrySample> history() const;
+    void clear();
+
+  private:
+    std::vector<TelemetrySample> samples_;
+    std::size_t windowSize_;
+};
+
+} // namespace minitrain

--- a/firmware/include/minitrain/train_controller.hpp
+++ b/firmware/include/minitrain/train_controller.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <mutex>
+
+#include "minitrain/pid_controller.hpp"
+#include "minitrain/telemetry.hpp"
+#include "minitrain/train_state.hpp"
+
+namespace minitrain {
+
+class TrainController {
+  public:
+    using MotorCommandWriter = std::function<void(float)>;
+    using TelemetryPublisher = std::function<void(const TelemetrySample &)>;
+
+    TrainController(PidController speedController, MotorCommandWriter motorWriter, TelemetryPublisher telemetryPublisher);
+
+    void setTargetSpeed(float metersPerSecond);
+    void setDirection(Direction direction);
+    void toggleHeadlights(bool enabled);
+    void toggleHorn(bool enabled);
+    void triggerEmergencyStop();
+
+    void onSpeedMeasurement(float measuredSpeed, std::chrono::steady_clock::duration dt);
+    void onTelemetrySample(const TelemetrySample &sample);
+
+    [[nodiscard]] TrainState state() const;
+    [[nodiscard]] std::optional<TelemetrySample> aggregatedTelemetry() const;
+
+  private:
+    mutable std::mutex mutex_;
+    TrainState state_;
+    PidController pid_;
+    MotorCommandWriter motorWriter_;
+    TelemetryPublisher telemetryPublisher_;
+    TelemetryAggregator telemetryAggregator_;
+};
+
+} // namespace minitrain

--- a/firmware/include/minitrain/train_state.hpp
+++ b/firmware/include/minitrain/train_state.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <chrono>
+
+namespace minitrain {
+
+enum class Direction {
+    Forward = 1,
+    Reverse = -1
+};
+
+struct TrainState {
+    Direction direction{Direction::Forward};
+    float targetSpeed{0.0F};
+    float appliedSpeed{0.0F};
+    bool headlights{false};
+    bool horn{false};
+    bool emergencyStop{false};
+    float batteryVoltage{0.0F};
+    std::chrono::steady_clock::time_point lastUpdated{std::chrono::steady_clock::now()};
+
+    void applyEmergencyStop();
+    void updateTargetSpeed(float newTarget);
+    void updateAppliedSpeed(float measuredSpeed);
+    void setDirection(Direction newDirection);
+    void setHeadlights(bool enabled);
+    void setHorn(bool enabled);
+    void setBatteryVoltage(float voltage);
+};
+
+} // namespace minitrain

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -1,0 +1,75 @@
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#include "minitrain/command_processor.hpp"
+#include "minitrain/pid_controller.hpp"
+#include "minitrain/train_controller.hpp"
+
+using namespace std::chrono_literals;
+
+int main() {
+    using minitrain::CommandProcessor;
+    using minitrain::Direction;
+    using minitrain::PidController;
+    using minitrain::TelemetrySample;
+    using minitrain::TrainController;
+
+    auto motorWriter = [](float command) { std::cout << "Motor PWM command: " << command << '\n'; };
+    auto telemetryPublisher = [](const TelemetrySample &sample) {
+        std::cout << "Telemetry: speed=" << sample.speedMetersPerSecond << " m/s, battery=" << sample.batteryVoltage
+                  << " V" << '\n';
+    };
+
+    TrainController controller(PidController{0.8F, 0.2F, 0.05F, 0.0F, 1.0F}, motorWriter, telemetryPublisher);
+
+    CommandProcessor processor;
+    processor.registerHandler("set_speed", [&controller](const auto &params) {
+        auto it = params.find("value");
+        if (it == params.end()) {
+            return minitrain::CommandResult{false, "Missing value"};
+        }
+        controller.setTargetSpeed(std::stof(it->second));
+        return minitrain::CommandResult{true, "Speed updated"};
+    });
+    processor.registerHandler("set_direction", [&controller](const auto &params) {
+        auto it = params.find("value");
+        if (it == params.end()) {
+            return minitrain::CommandResult{false, "Missing value"};
+        }
+        controller.setDirection(it->second == "reverse" ? Direction::Reverse : Direction::Forward);
+        return minitrain::CommandResult{true, "Direction updated"};
+    });
+    processor.registerHandler("headlights", [&controller](const auto &params) {
+        auto it = params.find("value");
+        if (it == params.end()) {
+            return minitrain::CommandResult{false, "Missing value"};
+        }
+        controller.toggleHeadlights(it->second == "on");
+        return minitrain::CommandResult{true, "Headlights toggled"};
+    });
+    processor.registerHandler("emergency", [&controller](const auto &params) {
+        (void)params;
+        controller.triggerEmergencyStop();
+        return minitrain::CommandResult{true, "Emergency stop"};
+    });
+
+    std::cout << "Controller ready. Type commands like 'command=set_speed;value=1.5' or 'command=emergency'" << '\n';
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        if (line == "quit") {
+            break;
+        }
+        try {
+            auto result = processor.process(line);
+            std::cout << (result.success ? "OK: " : "ERR: ") << result.message << '\n';
+        } catch (const std::exception &ex) {
+            std::cout << "ERR: " << ex.what() << '\n';
+        }
+
+        controller.onSpeedMeasurement(controller.state().targetSpeed * 0.8F, 100ms);
+        controller.onTelemetrySample(TelemetrySample{controller.state().targetSpeed, 0.5F, 11.1F, 30.0F});
+    }
+
+    return 0;
+}

--- a/firmware/src/command_processor.cpp
+++ b/firmware/src/command_processor.cpp
@@ -1,0 +1,62 @@
+#include "minitrain/command_processor.hpp"
+
+#include <cctype>
+#include <sstream>
+#include <stdexcept>
+
+namespace minitrain {
+
+CommandProcessor::CommandProcessor() = default;
+
+CommandResult CommandProcessor::process(const std::string &commandText) {
+    auto pairs = parseKeyValuePairs(commandText);
+    auto commandIt = pairs.find("command");
+    if (commandIt == pairs.end()) {
+        return {false, "Missing command key"};
+    }
+
+    const auto handlerIt = handlers_.find(commandIt->second);
+    if (handlerIt == handlers_.end()) {
+        return {false, "Unknown command: " + commandIt->second};
+    }
+
+    return handlerIt->second(pairs);
+}
+
+void CommandProcessor::registerHandler(const std::string &name, CommandHandler handler) {
+    handlers_[name] = std::move(handler);
+}
+
+std::unordered_map<std::string, std::string> CommandProcessor::parseKeyValuePairs(const std::string &commandText) {
+    std::unordered_map<std::string, std::string> result;
+    std::stringstream stream(commandText);
+    std::string token;
+
+    while (std::getline(stream, token, ';')) {
+        if (token.empty()) {
+            continue;
+        }
+        const auto delimiterPos = token.find('=');
+        if (delimiterPos == std::string::npos) {
+            throw std::invalid_argument("Invalid token: " + token);
+        }
+        std::string key = token.substr(0, delimiterPos);
+        std::string value = token.substr(delimiterPos + 1);
+        // trim spaces
+        auto trim = [](std::string &str) {
+            while (!str.empty() && std::isspace(static_cast<unsigned char>(str.front()))) {
+                str.erase(str.begin());
+            }
+            while (!str.empty() && std::isspace(static_cast<unsigned char>(str.back()))) {
+                str.pop_back();
+            }
+        };
+        trim(key);
+        trim(value);
+        result[key] = value;
+    }
+
+    return result;
+}
+
+} // namespace minitrain

--- a/firmware/src/pid_controller.cpp
+++ b/firmware/src/pid_controller.cpp
@@ -1,0 +1,38 @@
+#include "minitrain/pid_controller.hpp"
+
+#include <algorithm>
+
+namespace minitrain {
+
+PidController::PidController(float kp, float ki, float kd, float minOutput, float maxOutput)
+    : kp_{kp}, ki_{ki}, kd_{kd}, minOutput_{minOutput}, maxOutput_{maxOutput}, integral_{0.0F}, previousError_{0.0F},
+      hasPreviousError_{false} {}
+
+float PidController::update(float target, float measurement, std::chrono::steady_clock::duration dt) {
+    const float error = target - measurement;
+    const float seconds = std::chrono::duration<float>(dt).count();
+
+    if (seconds > 0.0F) {
+        integral_ += error * seconds;
+    }
+
+    float derivative = 0.0F;
+    if (hasPreviousError_ && seconds > 0.0F) {
+        derivative = (error - previousError_) / seconds;
+    }
+
+    previousError_ = error;
+    hasPreviousError_ = true;
+
+    float output = kp_ * error + ki_ * integral_ + kd_ * derivative;
+    output = std::clamp(output, minOutput_, maxOutput_);
+    return output;
+}
+
+void PidController::reset() {
+    integral_ = 0.0F;
+    previousError_ = 0.0F;
+    hasPreviousError_ = false;
+}
+
+} // namespace minitrain

--- a/firmware/src/telemetry.cpp
+++ b/firmware/src/telemetry.cpp
@@ -1,0 +1,48 @@
+#include "minitrain/telemetry.hpp"
+
+#include <numeric>
+
+namespace minitrain {
+
+TelemetryAggregator::TelemetryAggregator(std::size_t windowSize) : windowSize_{windowSize} {
+    samples_.reserve(windowSize_);
+}
+
+void TelemetryAggregator::addSample(const TelemetrySample &sample) {
+    if (samples_.size() == windowSize_) {
+        samples_.erase(samples_.begin());
+    }
+    samples_.push_back(sample);
+}
+
+std::optional<TelemetrySample> TelemetryAggregator::average() const {
+    if (samples_.empty()) {
+        return std::nullopt;
+    }
+
+    TelemetrySample result{};
+    for (const auto &sample : samples_) {
+        result.speedMetersPerSecond += sample.speedMetersPerSecond;
+        result.motorCurrentAmps += sample.motorCurrentAmps;
+        result.batteryVoltage += sample.batteryVoltage;
+        result.temperatureCelsius += sample.temperatureCelsius;
+    }
+
+    const float size = static_cast<float>(samples_.size());
+    result.speedMetersPerSecond /= size;
+    result.motorCurrentAmps /= size;
+    result.batteryVoltage /= size;
+    result.temperatureCelsius /= size;
+
+    return result;
+}
+
+std::vector<TelemetrySample> TelemetryAggregator::history() const {
+    return samples_;
+}
+
+void TelemetryAggregator::clear() {
+    samples_.clear();
+}
+
+} // namespace minitrain

--- a/firmware/src/train_controller.cpp
+++ b/firmware/src/train_controller.cpp
@@ -1,0 +1,76 @@
+#include "minitrain/train_controller.hpp"
+
+#include <algorithm>
+
+namespace minitrain {
+
+namespace {
+constexpr float clampMotorCommand(float value) {
+    return std::max(0.0F, std::min(1.0F, value));
+}
+} // namespace
+
+TrainController::TrainController(PidController speedController, MotorCommandWriter motorWriter,
+                                 TelemetryPublisher telemetryPublisher)
+    : state_{}, pid_{std::move(speedController)}, motorWriter_{std::move(motorWriter)},
+      telemetryPublisher_{std::move(telemetryPublisher)}, telemetryAggregator_{20} {}
+
+void TrainController::setTargetSpeed(float metersPerSecond) {
+    std::scoped_lock lock(mutex_);
+    state_.updateTargetSpeed(metersPerSecond);
+    if (state_.emergencyStop && metersPerSecond > 0.0F) {
+        state_.emergencyStop = false;
+    }
+}
+
+void TrainController::setDirection(Direction direction) {
+    std::scoped_lock lock(mutex_);
+    state_.setDirection(direction);
+}
+
+void TrainController::toggleHeadlights(bool enabled) {
+    std::scoped_lock lock(mutex_);
+    state_.setHeadlights(enabled);
+}
+
+void TrainController::toggleHorn(bool enabled) {
+    std::scoped_lock lock(mutex_);
+    state_.setHorn(enabled);
+}
+
+void TrainController::triggerEmergencyStop() {
+    std::scoped_lock lock(mutex_);
+    state_.applyEmergencyStop();
+    pid_.reset();
+    motorWriter_(0.0F);
+}
+
+void TrainController::onSpeedMeasurement(float measuredSpeed, std::chrono::steady_clock::duration dt) {
+    std::scoped_lock lock(mutex_);
+    state_.updateAppliedSpeed(measuredSpeed);
+    if (state_.emergencyStop) {
+        motorWriter_(0.0F);
+        return;
+    }
+    const float pidOutput = pid_.update(state_.targetSpeed, measuredSpeed, dt);
+    motorWriter_(clampMotorCommand(pidOutput));
+}
+
+void TrainController::onTelemetrySample(const TelemetrySample &sample) {
+    std::scoped_lock lock(mutex_);
+    telemetryAggregator_.addSample(sample);
+    state_.setBatteryVoltage(sample.batteryVoltage);
+    telemetryPublisher_(sample);
+}
+
+TrainState TrainController::state() const {
+    std::scoped_lock lock(mutex_);
+    return state_;
+}
+
+std::optional<TelemetrySample> TrainController::aggregatedTelemetry() const {
+    std::scoped_lock lock(mutex_);
+    return telemetryAggregator_.average();
+}
+
+} // namespace minitrain

--- a/firmware/src/train_state.cpp
+++ b/firmware/src/train_state.cpp
@@ -1,0 +1,52 @@
+#include "minitrain/train_state.hpp"
+
+#include <algorithm>
+
+namespace minitrain {
+
+namespace {
+constexpr float clamp(float value, float minValue, float maxValue) {
+    return std::max(minValue, std::min(maxValue, value));
+}
+} // namespace
+
+void TrainState::applyEmergencyStop() {
+    emergencyStop = true;
+    targetSpeed = 0.0F;
+    appliedSpeed = 0.0F;
+    lastUpdated = std::chrono::steady_clock::now();
+}
+
+void TrainState::updateTargetSpeed(float newTarget) {
+    targetSpeed = clamp(newTarget, 0.0F, 5.0F);
+    if (!emergencyStop) {
+        lastUpdated = std::chrono::steady_clock::now();
+    }
+}
+
+void TrainState::updateAppliedSpeed(float measuredSpeed) {
+    appliedSpeed = clamp(measuredSpeed, 0.0F, 5.0F);
+    lastUpdated = std::chrono::steady_clock::now();
+}
+
+void TrainState::setDirection(Direction newDirection) {
+    direction = newDirection;
+    lastUpdated = std::chrono::steady_clock::now();
+}
+
+void TrainState::setHeadlights(bool enabled) {
+    headlights = enabled;
+    lastUpdated = std::chrono::steady_clock::now();
+}
+
+void TrainState::setHorn(bool enabled) {
+    horn = enabled;
+    lastUpdated = std::chrono::steady_clock::now();
+}
+
+void TrainState::setBatteryVoltage(float voltage) {
+    batteryVoltage = clamp(voltage, 0.0F, 12.6F);
+    lastUpdated = std::chrono::steady_clock::now();
+}
+
+} // namespace minitrain

--- a/firmware/tests/test_command_processor.cpp
+++ b/firmware/tests/test_command_processor.cpp
@@ -1,0 +1,42 @@
+#include "minitrain/command_processor.hpp"
+
+#include <iostream>
+
+#include "test_suite.hpp"
+
+namespace minitrain::tests {
+
+int runCommandProcessorTests() {
+    CommandProcessor processor;
+    bool handlerCalled = false;
+    processor.registerHandler("set_speed", [&handlerCalled](const auto &params) {
+        handlerCalled = true;
+        auto it = params.find("value");
+        if (it == params.end() || it->second != "1.2") {
+            return CommandResult{false, "Unexpected value"};
+        }
+        return CommandResult{true, "OK"};
+    });
+
+    auto result = processor.process("command=set_speed;value=1.2");
+    if (!result.success || !handlerCalled) {
+        std::cerr << "Handler should have been executed" << std::endl;
+        return 1;
+    }
+
+    auto invalid = processor.process("command=unknown");
+    if (invalid.success || invalid.message.find("Unknown") == std::string::npos) {
+        std::cerr << "Unknown command should fail" << std::endl;
+        return 1;
+    }
+
+    auto malformed = processor.process("command=set_speed value=1.0");
+    if (malformed.success) {
+        std::cerr << "Malformed command should fail" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}
+
+} // namespace minitrain::tests

--- a/firmware/tests/test_main.cpp
+++ b/firmware/tests/test_main.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+
+#include "test_suite.hpp"
+
+int main() {
+    using namespace minitrain::tests;
+
+    int failures = 0;
+    failures += runPidControllerTests();
+    failures += runTelemetryTests();
+    failures += runCommandProcessorTests();
+    failures += runTrainControllerTests();
+
+    if (failures == 0) {
+        std::cout << "All firmware tests passed" << std::endl;
+    } else {
+        std::cout << failures << " firmware tests failed" << std::endl;
+    }
+
+    return failures == 0 ? 0 : 1;
+}

--- a/firmware/tests/test_pid_controller.cpp
+++ b/firmware/tests/test_pid_controller.cpp
@@ -1,0 +1,41 @@
+#include "minitrain/pid_controller.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <iostream>
+
+#include "test_suite.hpp"
+
+namespace minitrain::tests {
+
+int runPidControllerTests() {
+    PidController controller{1.0F, 0.1F, 0.01F, 0.0F, 1.0F};
+    auto dt = std::chrono::milliseconds{100};
+
+    float command = controller.update(1.0F, 0.0F, dt);
+    if (command <= 0.0F || command > 1.0F) {
+        std::cerr << "PID initial command out of range" << std::endl;
+        return 1;
+    }
+
+    controller.reset();
+    float command2 = controller.update(0.0F, 1.0F, dt);
+    if (command2 > 0.1F) {
+        std::cerr << "PID command should be near zero when measurement exceeds target" << std::endl;
+        return 1;
+    }
+
+    controller.reset();
+    float previous = 0.0F;
+    for (int i = 0; i < 10; ++i) {
+        previous = controller.update(2.0F, 1.0F + 0.05F * static_cast<float>(i), dt);
+    }
+    if (previous < 0.2F) {
+        std::cerr << "PID should accumulate integral contribution" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}
+
+} // namespace minitrain::tests

--- a/firmware/tests/test_suite.hpp
+++ b/firmware/tests/test_suite.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace minitrain::tests {
+
+int runPidControllerTests();
+int runTelemetryTests();
+int runCommandProcessorTests();
+int runTrainControllerTests();
+
+} // namespace minitrain::tests

--- a/firmware/tests/test_telemetry.cpp
+++ b/firmware/tests/test_telemetry.cpp
@@ -1,0 +1,41 @@
+#include "minitrain/telemetry.hpp"
+
+#include <iostream>
+
+#include "test_suite.hpp"
+
+namespace minitrain::tests {
+
+int runTelemetryTests() {
+    TelemetryAggregator aggregator{3};
+    aggregator.addSample(TelemetrySample{1.0F, 0.5F, 11.1F, 30.0F});
+    aggregator.addSample(TelemetrySample{1.5F, 0.6F, 11.0F, 31.0F});
+    aggregator.addSample(TelemetrySample{2.0F, 0.7F, 10.9F, 32.0F});
+
+    auto avg = aggregator.average();
+    if (!avg) {
+        std::cerr << "Average should be available" << std::endl;
+        return 1;
+    }
+    if (avg->speedMetersPerSecond < 1.4F || avg->speedMetersPerSecond > 1.6F) {
+        std::cerr << "Unexpected average speed" << std::endl;
+        return 1;
+    }
+
+    aggregator.addSample(TelemetrySample{2.5F, 0.8F, 10.8F, 33.0F});
+    auto history = aggregator.history();
+    if (history.size() != 3 || history.front().speedMetersPerSecond != 1.5F) {
+        std::cerr << "Aggregator should drop old samples" << std::endl;
+        return 1;
+    }
+
+    aggregator.clear();
+    if (aggregator.average()) {
+        std::cerr << "Average should be empty after clear" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}
+
+} // namespace minitrain::tests

--- a/firmware/tests/test_train_controller.cpp
+++ b/firmware/tests/test_train_controller.cpp
@@ -1,0 +1,74 @@
+#include "minitrain/train_controller.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <vector>
+
+#include "test_suite.hpp"
+
+namespace minitrain::tests {
+
+int runTrainControllerTests() {
+    std::vector<float> motorCommands;
+    std::vector<TelemetrySample> publishedTelemetry;
+
+    TrainController controller(PidController{0.5F, 0.05F, 0.01F, 0.0F, 1.0F},
+                               [&motorCommands](float command) { motorCommands.push_back(command); },
+                               [&publishedTelemetry](const TelemetrySample &sample) {
+                                   publishedTelemetry.push_back(sample);
+                               });
+
+    controller.setTargetSpeed(1.5F);
+    controller.onSpeedMeasurement(0.5F, std::chrono::milliseconds{50});
+    controller.onTelemetrySample(TelemetrySample{1.2F, 0.4F, 11.2F, 29.0F});
+
+    if (motorCommands.empty() || motorCommands.back() <= 0.0F) {
+        std::cerr << "Motor command should be positive" << std::endl;
+        return 1;
+    }
+
+    auto state = controller.state();
+    if (state.targetSpeed < 1.49F || state.targetSpeed > 1.51F) {
+        std::cerr << "Target speed should be stored" << std::endl;
+        return 1;
+    }
+
+    controller.triggerEmergencyStop();
+    if (!controller.state().emergencyStop) {
+        std::cerr << "Emergency stop flag should be set" << std::endl;
+        return 1;
+    }
+
+    controller.onSpeedMeasurement(1.0F, std::chrono::milliseconds{50});
+    if (!motorCommands.empty() && motorCommands.back() != 0.0F) {
+        std::cerr << "Motor command should be zero after emergency" << std::endl;
+        return 1;
+    }
+
+    if (publishedTelemetry.empty()) {
+        std::cerr << "Telemetry should be published" << std::endl;
+        return 1;
+    }
+
+    auto aggregated = controller.aggregatedTelemetry();
+    if (!aggregated || aggregated->batteryVoltage < 11.0F) {
+        std::cerr << "Aggregated telemetry should track battery voltage" << std::endl;
+        return 1;
+    }
+
+    controller.setTargetSpeed(0.0F);
+    if (!controller.state().emergencyStop) {
+        std::cerr << "Emergency should persist while zero speed requested" << std::endl;
+        return 1;
+    }
+
+    controller.setTargetSpeed(0.5F);
+    if (controller.state().emergencyStop) {
+        std::cerr << "Emergency flag should reset when non-zero speed requested" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}
+
+} // namespace minitrain::tests


### PR DESCRIPTION
## Summary
- add modular C++ firmware core with command handling, telemetry aggregation, and PID-based motor control plus simulation entrypoint
- create Kotlin-based control application logic with repository, view-model, and protocol utilities for Android integration
- provide comprehensive unit tests for firmware components and Kotlin logic along with build tooling and documentation updates

## Testing
- cmake -S firmware -B firmware/build
- cmake --build firmware/build
- ctest --test-dir firmware/build
- gradle test --console=plain > gradle-test.log 2>&1

------
https://chatgpt.com/codex/tasks/task_e_68e146ef8c188322801194046813973a