### PR TITLE
Add Docker setup for firmware and app builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        openjdk-17-jdk \
+        gradle \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+COPY . /workspace
+
+RUN cmake -S firmware -B firmware/build \
+    && cmake --build firmware/build \
+    && ctest --test-dir firmware/build
+
+RUN cd android-app \
+    && gradle --no-daemon test
+
+CMD ["/bin/bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+
+services:
+  build-and-test:
+    build:
+      context: .
+    image: minitrain/build
+    container_name: minitrain-build
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    command: >-
+      bash -lc "cmake -S firmware -B firmware/build && \
+      cmake --build firmware/build && \
+      ctest --test-dir firmware/build && \
+      cd android-app && gradle --no-daemon test"


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs build dependencies and runs the firmware and Android builds/tests
- add a docker-compose service to execute the same build pipeline in an isolated container

## Testing
- not run (container-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e15d78cb808322b0f6e07f4a6dc953