### PR TITLE
Fix Docker build for JDK 21 and add JVM toolchain test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
         cmake \
-        openjdk-17-jdk \
+        openjdk-21-jdk \
         gradle \
         git \
     && rm -rf /var/lib/apt/lists/*
@@ -15,6 +15,9 @@ RUN apt-get update \
 WORKDIR /workspace
 
 COPY . /workspace
+
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+ENV PATH="$JAVA_HOME/bin:$PATH"
 
 RUN cmake -S firmware -B firmware/build \
     && cmake --build firmware/build \

--- a/android-app/app/src/test/kotlin/com/minitrain/app/JvmToolchainTest.kt
+++ b/android-app/app/src/test/kotlin/com/minitrain/app/JvmToolchainTest.kt
@@ -1,0 +1,18 @@
+package com.minitrain.app
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class JvmToolchainTest {
+    @Test
+    fun `uses java 21 runtime`() {
+        val specVersion = System.getProperty("java.specification.version")
+        val majorVersion = specVersion
+            ?.substringBefore('.')
+            ?.toIntOrNull()
+        assertTrue(
+            majorVersion != null && majorVersion >= 21,
+            "Les tests doivent s'exécuter avec une JVM 21 ou supérieure, version actuelle: $specVersion"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- install OpenJDK 21 in the Docker image and expose JAVA_HOME so Gradle finds the required toolchain
- add a JVM specification version unit test to ensure the Android app logic is exercised with Java 21+

## Testing
- cmake --build firmware/build
- ctest --test-dir firmware/build
- gradle --no-daemon --console=plain test

------
https://chatgpt.com/codex/tasks/task_e_68e18c8e15f48322ac173e05766a5ef2